### PR TITLE
Use std::time API instead of u64s for timestamp and expiry time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 This repo provides datastructures for BOLT 11 lightning invoices.
 It provides functions to parse and serialize invoices from and to bech32.
 
+**Please be sure to run the test suite since we need to check assumptions
+regarding `SystemTime`'s bounds on your platform.**
+
 ## Contributing
 * same coding style standard as [rust-bitcoin/rust-lightning](https://github.com/rust-bitcoin/rust-lightning)
 * use tabs and spaces (appropriately)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repo provides datastructures for BOLT 11 lightning invoices.
 It provides functions to parse and serialize invoices from and to bech32.
 
 **Please be sure to run the test suite since we need to check assumptions
-regarding `SystemTime`'s bounds on your platform.**
+regarding `SystemTime`'s bounds on your platform. You can also call `check_platform`
+on startup or in your test suite to do so.**
 
 ## Contributing
 * same coding style standard as [rust-bitcoin/rust-lightning](https://github.com/rust-bitcoin/rust-lightning)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,16 +479,6 @@ impl<D: tb::Bool, T: tb::Bool> InvoiceBuilder<D, tb::False, T> {
 }
 
 impl<D: tb::Bool, H: tb::Bool> InvoiceBuilder<D, H, tb::False> {
-	/// Sets the timestamp. `time` is a UNIX timestamp.
-	pub fn timestamp_raw(mut self, time: u64) -> InvoiceBuilder<D, H, tb::True> {
-		match PositiveTimestamp::from_unix_timestamp(time) {
-			Ok(t) => self.timestamp = Some(t),
-			Err(e) => self.error = Some(e),
-		}
-
-		self.set_flags()
-	}
-
 	/// Sets the timestamp.
 	pub fn timestamp(mut self, time: SystemTime) -> InvoiceBuilder<D, H, tb::True> {
 		match PositiveTimestamp::from_system_time(time) {
@@ -1407,7 +1397,7 @@ mod test {
 
 		let builder = InvoiceBuilder::new(Currency::BitcoinTestnet)
 			.amount_pico_btc(123)
-			.timestamp_raw(1234567)
+			.timestamp(UNIX_EPOCH + Duration::from_secs(1234567))
 			.payee_pub_key(public_key.clone())
 			.expiry_time(Duration::from_secs(54321))
 			.min_final_cltv_expiry(144)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -170,7 +170,7 @@ impl ToBase32<Vec<u5>> for PayeePubKey {
 
 impl ToBase32<Vec<u5>> for ExpiryTime {
 	fn to_base32(&self) -> Vec<u5> {
-		encode_int_be_base32(self.seconds)
+		encode_int_be_base32(self.as_seconds())
 	}
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -119,7 +119,7 @@ impl ToBase32<Vec<u5>> for RawDataPart {
 		let mut encoded = Vec::<u5>::new();
 
 		// encode timestamp
-		encoded.extend(&encode_int_be_base32(self.timestamp));
+		encoded.extend(self.timestamp.to_base32());
 
 		// encode tagged fields
 		for tagged_field in self.tagged_fields.iter() {
@@ -127,6 +127,13 @@ impl ToBase32<Vec<u5>> for RawDataPart {
 		}
 
 		encoded
+	}
+}
+
+impl ToBase32<Vec<u5>> for PositiveTimestamp {
+	fn to_base32(&self) -> Vec<u5> {
+		try_stretch(encode_int_be_base32(self.as_unix_timestamp()), 7)
+			.expect("Can't be longer due than 7 u5s due to timestamp bounds")
 	}
 }
 

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -6,7 +6,7 @@ use bitcoin_hashes::hex::FromHex;
 use bitcoin_hashes::sha256::Sha256Hash;
 use lightning_invoice::*;
 use secp256k1::{Secp256k1, RecoverableSignature, RecoveryId};
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 // TODO: add more of the examples from BOLT11 and generate ones causing SemanticErrors
 
@@ -17,7 +17,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			wd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9\
 			ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
-				.timestamp_raw(1496314658)
+				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
 				.payment_hash(Sha256Hash::from_hex(
 						"0001020304050607080900010203040506070809000102030405060708090102"
 				).unwrap())
@@ -46,7 +46,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			9zw97j25emudupq63nyw24cg27h2rspfj9srp".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_pico_btc(2500000000)
-				.timestamp_raw(1496314658)
+				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
 				.payment_hash(Sha256Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
 				).unwrap())
@@ -76,7 +76,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			hhr8wpald05e92xw006sq94mg8v2ndf4sefvf9sygkshp5zfem29trqq2yxxz7".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_pico_btc(20000000000)
-				.timestamp_raw(1496314658)
+				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
 				.payment_hash(Sha256Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
 				).unwrap())

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -16,7 +16,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			wd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9\
 			ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
-				.timestamp(1496314658)
+				.timestamp_raw(1496314658)
 				.payment_hash(Sha256Hash::from_hex(
 						"0001020304050607080900010203040506070809000102030405060708090102"
 				).unwrap())
@@ -45,7 +45,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			9zw97j25emudupq63nyw24cg27h2rspfj9srp".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_pico_btc(2500000000)
-				.timestamp(1496314658)
+				.timestamp_raw(1496314658)
 				.payment_hash(Sha256Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
 				).unwrap())
@@ -75,7 +75,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			hhr8wpald05e92xw006sq94mg8v2ndf4sefvf9sygkshp5zfem29trqq2yxxz7".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_pico_btc(20000000000)
-				.timestamp(1496314658)
+				.timestamp_raw(1496314658)
 				.payment_hash(Sha256Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
 				).unwrap())

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -6,6 +6,7 @@ use bitcoin_hashes::hex::FromHex;
 use bitcoin_hashes::sha256::Sha256Hash;
 use lightning_invoice::*;
 use secp256k1::{Secp256k1, RecoverableSignature, RecoveryId};
+use std::time::Duration;
 
 // TODO: add more of the examples from BOLT11 and generate ones causing SemanticErrors
 
@@ -50,7 +51,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 					"0001020304050607080900010203040506070809000102030405060708090102"
 				).unwrap())
 				.description("1 cup coffee".to_owned())
-				.expiry_time_seconds(60)
+				.expiry_time(Duration::from_secs(60))
 				.build_raw()
 				.unwrap()
 				.sign(|_| {


### PR DESCRIPTION
Using dedicated time structs should make the API less error prone and easier to use right. Since we don't want to pull in unnecessary Dependencies I didn't use `chrono`.

But `std::time` unfortunately misses a way to do time calculations (like `SystemTime + Duration`) in a non-panicking way (see rust-lang/rust#55527). So I had to make some wild guesses about our potential target platforms and their internal representations of time which can't be statically asserted yet unfortunately. That means we end up with some really ugly heuristics that try to keep people from using the library in ways that would expose them to DoS attacks by overflowing the time calculations.

```rust
// TODO: fix before 2037 (see rust PR #55527)
/// Defines the maximum UNIX timestamp that can be represented as `SystemTime`. This is checked by
/// one of the unit tests, please run them.
const SYSTEM_TIME_MAX_UNIX_TIMESTAMP: u64 = std::i32::MAX as u64;

/// Allow the expiry time to be up to one year. Since this reduces the range of possible timestamps
/// it should be rather low as long as we still have to support 32bit time representations
const MAX_EXPIRY_TIME: u64 = 60 * 60 * 24 * 356;

/// This function is used as a static assert for the size of `SystemTime`. If the crate fails to
/// compile due to it this indicates that your system uses unexpected bounds for `SystemTime`. You
/// can remove this functions and run the test `test_system_time_bounds_assumptions`. In any case,
/// please open an issue. If all tests pass you should be able to use this library safely by just
/// removing this function till we patch it accordingly.
fn __system_time_size_check() {
	/// Use 2 * sizeof(u64) as expected size since the expected underlying implementation is storing
	/// a `Duration` since `SystemTime::UNIX_EPOCH`.
	unsafe { std::mem::transmute::<SystemTime, [u8; 16]>(UNIX_EPOCH); }
}
```

I nonetheless think that it's the right thing to improve the API in that way. With some luck my rust-lang PR will end up in the debian stable rust release in the next decade :sob: but it's ok as long as that will happen before 2037 :smile:

Since @TheBlueMatt is the only user of this library I know of: what do you think about that change. I think that was the last short-term API-breaking change, so I'd really like to publish a `0.1.0` soon.