### PR TITLE
Fix linter nits

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -582,6 +582,9 @@ impl FromBase32 for Route {
 	}
 }
 
+/// Errors that indicate what is wrong with the invoice. They have some granularity for debug
+/// reasons, but should generally result in an "invalid BOLT11 invoice" message for the user.
+#[allow(missing_docs)]
 #[derive(PartialEq, Debug, Clone)]
 pub enum ParseError {
 	Bech32Error(bech32::Error),
@@ -601,13 +604,22 @@ pub enum ParseError {
 	InvalidScriptHashLength,
 	InvalidRecoveryId,
 	InvalidSliceLength(String),
+
+	/// Not an error, but used internally to signal that a part of the invoice should be ignored
+	/// according to BOLT11
 	Skip,
 	TimestampOverflow,
 }
 
+/// Indicates that something went wrong while parsing or validating the invoice. Parsing errors
+/// should be mostly seen as opaque and are only there for debugging reasons. Semantic errors
+/// like wrong signatures, missing fields etc. could mean that someone tampered with the invoice.
 #[derive(PartialEq, Debug, Clone)]
 pub enum ParseOrSemanticError {
+	/// The invoice couldn't be decoded
 	ParseError(ParseError),
+
+	/// The invoice could be decoded but violates the BOLT11 standard
 	SemanticError(::SemanticError),
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -80,11 +80,7 @@ mod hrp_sm {
 		}
 
 		fn is_final(&self) -> bool {
-			if *self == States::ParseL || *self == States::ParseN {
-				false
-			} else {
-				true
-			}
+			!(*self == States::ParseL || *self == States::ParseN)
 		}
 	}
 
@@ -710,7 +706,6 @@ mod test {
 	use de::ParseError;
 	use secp256k1::{PublicKey, Secp256k1};
 	use bech32::u5;
-	use SignedRawInvoice;
 	use bitcoin_hashes::hex::FromHex;
 	use bitcoin_hashes::sha256::Sha256Hash;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -46,9 +46,9 @@ impl Display for RawHrp {
 
 impl Display for Currency {
 	fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-		let currency_code = match self {
-			&Currency::Bitcoin => "bc",
-			&Currency::BitcoinTestnet => "tb",
+		let currency_code = match *self {
+			Currency::Bitcoin => "bc",
+			Currency::BitcoinTestnet => "tb",
 		};
 		write!(f, "{}", currency_code)
 	}


### PR DESCRIPTION
 Make the rustc linter and clippy as happy as possible while staying to rust 1.14.0. Depends on #8 .