### PR TITLE
WIP: Use bitcoin-constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ bech32 = "0.5.0"
 secp256k1 = "0.12"
 num-traits = "0.2"
 bitcoin_hashes = "0.1"
+bitcoin-constants = {git = "https://github.com/sgeisler/bitcoin-constants.git", branch = "chain_params_impl"}

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -35,20 +35,10 @@ impl Display for RawHrp {
 		write!(
 			f,
 			"ln{}{}{}",
-			self.currency,
+			self.currency.hrp(),
 			amount,
 			si_prefix
 		)
-	}
-}
-
-impl Display for Currency {
-	fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-		let currency_code = match *self {
-			Currency::Bitcoin => "bc",
-			Currency::BitcoinTestnet => "tb",
-		};
-		write!(f, "{}", currency_code)
 	}
 }
 
@@ -300,19 +290,11 @@ mod test {
 	use bech32::CheckBase32;
 
 	#[test]
-	fn test_currency_code() {
-		use Currency;
-
-		assert_eq!("bc", Currency::Bitcoin.to_string());
-		assert_eq!("tb", Currency::BitcoinTestnet.to_string());
-	}
-
-	#[test]
 	fn test_raw_hrp() {
-		use ::{Currency, RawHrp, SiPrefix};
+		use ::{Network, RawHrp, SiPrefix};
 
 		let hrp = RawHrp {
-			currency: Currency::Bitcoin,
+			currency: Network::bitcoin(),
 			raw_amount: Some(100),
 			si_prefix: Some(SiPrefix::Micro),
 		};

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -16,7 +16,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			"lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmw\
 			wd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9\
 			ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w".to_owned(),
-			InvoiceBuilder::new(Currency::Bitcoin)
+			InvoiceBuilder::new(Network::bitcoin())
 				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
 				.payment_hash(sha256::Hash::from_hex(
 						"0001020304050607080900010203040506070809000102030405060708090102"
@@ -43,7 +43,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3\
 			k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch\
 			9zw97j25emudupq63nyw24cg27h2rspfj9srp".to_owned(),
-			InvoiceBuilder::new(Currency::Bitcoin)
+			InvoiceBuilder::new(Network::bitcoin())
 				.amount_pico_btc(2500000000)
 				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
 				.payment_hash(sha256::Hash::from_hex(
@@ -72,7 +72,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 			"lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qq\
 			dhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqscc6gd6ql3jrc5yzme8v4ntcewwz5cnw92tz0pc8qcuufvq7k\
 			hhr8wpald05e92xw006sq94mg8v2ndf4sefvf9sygkshp5zfem29trqq2yxxz7".to_owned(),
-			InvoiceBuilder::new(Currency::Bitcoin)
+			InvoiceBuilder::new(Network::bitcoin())
 				.amount_pico_btc(20000000000)
 				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
 				.payment_hash(sha256::Hash::from_hex(


### PR DESCRIPTION
Fixes #16. Use `bitcoin_constants::Network` instead of custom `Currency` enum.

- [ ] Change `bitcoin_constants` dependency to crates.io version when it gets published