### PR TITLE
WIP: Avoid unnecessary allocation during serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [ "lightning", "bitcoin", "invoice", "BOLT11" ]
 readme = "README.md"
 
 [dependencies]
-bech32 = "0.6.0"
+bech32 = {git="https://github.com/sgeisler/rust-bech32", branch="to_base_buffer"}
 secp256k1 = "0.12"
 num-traits = "0.2"
 bitcoin_hashes = "0.3"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ honggfuzz_fuzz = ["honggfuzz"]
 honggfuzz = { version = "0.5", optional = true }
 afl = { version = "0.4", optional = true }
 lightning-invoice = { path = ".."}
-bech32 = "0.6.0"
+bech32 = {git="https://github.com/sgeisler/rust-bech32", branch="to_base_buffer"}
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
Pass a mut buffer reference instead of returning vectors ans concatenating them again.