### PR TITLE
Add Regtest support.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -178,6 +178,7 @@ impl FromStr for super::Currency {
 		match currency_prefix {
 			"bc" => Ok(Currency::Bitcoin),
 			"tb" => Ok(Currency::BitcoinTestnet),
+			"bcrt" => Ok(Currency::Regtest),
 			_ => Err(ParseError::UnknownCurrency)
 		}
 	}
@@ -744,6 +745,7 @@ mod test {
 
 		assert_eq!("bc".parse::<Currency>(), Ok(Currency::Bitcoin));
 		assert_eq!("tb".parse::<Currency>(), Ok(Currency::BitcoinTestnet));
+		assert_eq!("bcrt".parse::<Currency>(), Ok(Currency::Regtest));
 		assert_eq!("something_else".parse::<Currency>(), Err(ParseError::UnknownCurrency))
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,7 @@ impl SiPrefix {
 pub enum Currency {
 	Bitcoin,
 	BitcoinTestnet,
+	Regtest,
 }
 
 /// Tagged field which may have an unknown tag

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -47,6 +47,7 @@ impl Display for Currency {
 		let currency_code = match *self {
 			Currency::Bitcoin => "bc",
 			Currency::BitcoinTestnet => "tb",
+			Currency::Regtest => "bcrt",
 		};
 		write!(f, "{}", currency_code)
 	}
@@ -305,6 +306,7 @@ mod test {
 
 		assert_eq!("bc", Currency::Bitcoin.to_string());
 		assert_eq!("tb", Currency::BitcoinTestnet.to_string());
+		assert_eq!("bcrt", Currency::Regtest.to_string());
 	}
 
 	#[test]


### PR DESCRIPTION
Add Regtest Support to the library.
keep rust-lightning running [here](https://github.com/TheBlueMatt/rust-lightning-bitcoinrpc/blob/272c91bd6449151c8e23c80d66e924a3dd6624c3/src/main.rs#L675)