### PR TITLE
use newer version of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 
 [dependencies]
 bech32 = "0.6.0"
-secp256k1 = "0.12"
-num-traits = "0.2"
-bitcoin_hashes = "0.3"
+secp256k1 = { version = "0.14.1", features = ["recovery"] }
+num-traits = "0.2.8"
+bitcoin_hashes = "0.6.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+

--- a/src/de.rs
+++ b/src/de.rs
@@ -14,7 +14,7 @@ use bitcoin_hashes::sha256;
 use num_traits::{CheckedAdd, CheckedMul};
 
 use secp256k1;
-use secp256k1::{RecoveryId, RecoverableSignature};
+use secp256k1::recovery::{RecoveryId, RecoverableSignature};
 use secp256k1::key::PublicKey;
 
 use super::*;
@@ -947,7 +947,7 @@ mod test {
 	#[test]
 	fn test_raw_signed_invoice_deserialization() {
 		use TaggedField::*;
-		use secp256k1::{RecoveryId, RecoverableSignature};
+		use secp256k1::recovery::{RecoveryId, RecoverableSignature};
 		use {SignedRawInvoice, Signature, RawInvoice, RawHrp, RawDataPart, Currency, Sha256,
 			 PositiveTimestamp};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@ use bitcoin_hashes::Hash;
 use bitcoin_hashes::sha256;
 
 use secp256k1::key::PublicKey;
-use secp256k1::{Message, RecoverableSignature, Secp256k1};
+use secp256k1::{Message, Secp256k1};
+use secp256k1::recovery::RecoverableSignature;
 use std::ops::Deref;
 
 use std::iter::FilterMap;
@@ -74,8 +75,6 @@ fn __system_time_size_check() {
 /// If the check fails this function panics. By calling this function on startup you ensure that
 /// this wont happen at an arbitrary later point in time.
 pub fn check_platform() {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
     // The upper and lower bounds of `SystemTime` are not part of its public contract and are
     // platform specific. That's why we have to test if our assumptions regarding these bounds
     // hold on the target platform.
@@ -561,7 +560,6 @@ impl<D: tb::Bool, H: tb::Bool> InvoiceBuilder<D, H, tb::False> {
 
 	/// Sets the timestamp to the current UNIX timestamp.
 	pub fn current_timestamp(mut self) -> InvoiceBuilder<D, H, tb::True> {
-		use std::time::SystemTime;
 		let now = PositiveTimestamp::from_system_time(SystemTime::now());
 		self.timestamp = Some(now.expect("for the foreseeable future this shouldn't happen"));
 		self.set_flags()
@@ -1282,7 +1280,8 @@ mod test {
 	#[test]
 	fn test_check_signature() {
 		use TaggedField::*;
-		use secp256k1::{RecoveryId, RecoverableSignature, Secp256k1};
+		use secp256k1::Secp256k1;
+		use secp256k1::recovery::{RecoveryId, RecoverableSignature};
 		use secp256k1::key::{SecretKey, PublicKey};
 		use {SignedRawInvoice, Signature, RawInvoice, RawHrp, RawDataPart, Currency, Sha256,
 			 PositiveTimestamp};

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -5,7 +5,7 @@ extern crate secp256k1;
 use bitcoin_hashes::hex::FromHex;
 use bitcoin_hashes::sha256;
 use lightning_invoice::*;
-use secp256k1::{RecoverableSignature, RecoveryId};
+use secp256k1::recovery::{RecoverableSignature, RecoveryId};
 use std::time::{Duration, UNIX_EPOCH};
 
 // TODO: add more of the examples from BOLT11 and generate ones causing SemanticErrors


### PR DESCRIPTION
Updated secp256k1 to 0.14.1 . It introduced some breaking changes.
This commit fixes them.
Fixed some warnings.