### PR TITLE
Add simnet support

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -179,6 +179,7 @@ impl FromStr for super::Currency {
 			"bc" => Ok(Currency::Bitcoin),
 			"tb" => Ok(Currency::BitcoinTestnet),
 			"bcrt" => Ok(Currency::Regtest),
+			"sb" => Ok(Currency::Simnet),
 			_ => Err(ParseError::UnknownCurrency)
 		}
 	}
@@ -746,6 +747,7 @@ mod test {
 		assert_eq!("bc".parse::<Currency>(), Ok(Currency::Bitcoin));
 		assert_eq!("tb".parse::<Currency>(), Ok(Currency::BitcoinTestnet));
 		assert_eq!("bcrt".parse::<Currency>(), Ok(Currency::Regtest));
+		assert_eq!("sb".parse::<Currency>(), Ok(Currency::Simnet));
 		assert_eq!("something_else".parse::<Currency>(), Err(ParseError::UnknownCurrency))
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,9 +289,17 @@ impl SiPrefix {
 #[allow(missing_docs)]
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum Currency {
+	/// Bitcoin mainnet
 	Bitcoin,
+
+	/// Bitcoin testnet
 	BitcoinTestnet,
+
+	/// Bitcoin regtest
 	Regtest,
+
+	/// Bitcoin (`btcd`) simnet
+	Simnet,
 }
 
 /// Tagged field which may have an unknown tag

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,8 +285,7 @@ impl SiPrefix {
 	}
 }
 
-/// Enum representing the crypto currencies supported by this library
-#[allow(missing_docs)]
+/// Enum representing the crypto currencies (or networks) supported by this library
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum Currency {
 	/// Bitcoin mainnet
@@ -298,7 +297,7 @@ pub enum Currency {
 	/// Bitcoin regtest
 	Regtest,
 
-	/// Bitcoin (`btcd`) simnet
+	/// Bitcoin simnet/signet
 	Simnet,
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -150,6 +150,7 @@ impl Display for Currency {
 			Currency::Bitcoin => "bc",
 			Currency::BitcoinTestnet => "tb",
 			Currency::Regtest => "bcrt",
+			Currency::Simnet => "sb",
 		};
 		write!(f, "{}", currency_code)
 	}
@@ -459,6 +460,7 @@ mod test {
 		assert_eq!("bc", Currency::Bitcoin.to_string());
 		assert_eq!("tb", Currency::BitcoinTestnet.to_string());
 		assert_eq!("bcrt", Currency::Regtest.to_string());
+		assert_eq!("sb", Currency::Simnet.to_string());
 	}
 
 	#[test]


### PR DESCRIPTION
Adds support for `btcd`'s [simnet](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#simnet-vs-testnet-development) invoices. Like this one:

```
lnsb10n1p0d5jk4pp5vmtk54n898lll0uxt046kldflxvcdcjep5ysy2vnkf895n8fy3sqdqqcqzpgsp5lrvflcjjk95u0tdrunw402sgrteewrt7fhf0yn6set38lkrw24aq9qy9qsq4y4c904e8pvx47q98qdjuuw2vaqrq8lex9sx430xfuzjz3h2wrtpph3nd7r3mpghu0cfl2upqfjc906p580hzttwskcznyumgc8n75cqmee969
```