### PR TITLE
Fix: Display and Error impls for ParseOrSemanticError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,16 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.22.0 # min. supported rust version
 cache: cargo
 
 jobs:
   include:
+  - rust: 1.29.0
+    script:
+      - cargo generate-lockfile --verbose
+      - cargo update -p cc --precise "1.0.41" --verbose
+      - cargo build
+      - cargo test
   - stage: fuzz
     before_install:
       - sudo apt-get -qq update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lightning-invoice"
 description = "Data structures to parse and serialize BOLT11 lightning invoices"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sebastian Geisler <sgeisler@wh2.tu-dresden.de>"]
 license = "Apache-2.0"
 documentation = "https://docs.rs/lightning-invoice/"
@@ -11,9 +11,9 @@ readme = "README.md"
 
 [dependencies]
 bech32 = "0.7"
-secp256k1 = { version = "0.17", features = ["recovery"] }
+secp256k1 = { version = "0.20", features = ["recovery"] }
 num-traits = "0.2.8"
-bitcoin_hashes = "0.7"
+bitcoin_hashes = "0.9.4"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -516,7 +516,7 @@ impl FromBase32 for Fallback {
 		let bytes = Vec::<u8>::from_base32(&field_data[1..])?;
 
 		match version.to_u8() {
-			0...16 => {
+			0..=16 => {
 				if bytes.len() < 2 || bytes.len() > 40 {
 					return Err(ParseError::InvalidSegWitProgramLength);
 				}

--- a/src/de.rs
+++ b/src/de.rs
@@ -652,6 +652,15 @@ impl Display for ParseError {
 	}
 }
 
+impl Display for ParseOrSemanticError {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match self {
+			ParseOrSemanticError::ParseError(err) => err.fmt(f),
+			ParseOrSemanticError::SemanticError(err) => err.fmt(f),
+		}
+	}
+}
+
 impl error::Error for ParseError {
 	fn description(&self) -> &str {
 		use self::ParseError::*;
@@ -678,6 +687,8 @@ impl error::Error for ParseError {
 		}
 	}
 }
+
+impl error::Error for ParseOrSemanticError {}
 
 macro_rules! from_error {
     ($my_error:expr, $extern_error:ty) => {


### PR DESCRIPTION
`ParseOrSemanticError` was missing `Display` and `Error` implementations before. This fixes the issue.

I did no `description` since the method is deprecated and existing error descriptions should be refactored in the next PRs anyway